### PR TITLE
This is required in order to cooperate with StarTeam AppControl (2009 and higher)

### DIFF
--- a/src/main/java/hudson/plugins/starteam/StarTeamConnection.java
+++ b/src/main/java/hudson/plugins/starteam/StarTeamConnection.java
@@ -171,7 +171,7 @@ public class StarTeamConnection implements Serializable {
 		   that take advantage of this feature.  This must be called before a connection
 		   to the server is established.
 		*/ 
-		ClientAppplication.setName("StarTeam Plugin for Hudson");
+		ClientApplication.setName("StarTeam Plugin for Jenkins");
 		
 		server = new Server(createServerInfo());
 		server.connect();


### PR DESCRIPTION
Identify this as the StarTeam Hudson Plugin so that it can support the new AppControl capability in StarTeam 2009 which allows a StarTeam administrator to block or allow Unknown or specific client/SDK applications from accessing the repository; without this, the plugin will be seen as an Unknown Client, and may be blocked by StarTeam repositories that take advantage of this feature
