### PR TITLE
Added switch to ignore working folders and use a relative folder hierarchy

### DIFF
--- a/src/main/java/hudson/plugins/starteam/StarTeamConnection.java
+++ b/src/main/java/hudson/plugins/starteam/StarTeamConnection.java
@@ -452,10 +452,10 @@ public class StarTeamConnection implements Serializable {
 	 * @throws StarTeamSCMException
 	 * @throws IOException
 	 */
-	public StarTeamChangeSet computeChangeSet(Folder rootFolder, java.io.File workspace, final Collection<StarTeamFilePoint> historicFilePoints, PrintStream logger) throws StarTeamSCMException, IOException {
+	public StarTeamChangeSet computeChangeSet(Folder rootFolder, boolean ignoreWorkingFolder, java.io.File workspace, final Collection<StarTeamFilePoint> historicFilePoints, PrintStream logger) throws StarTeamSCMException, IOException {
 	    // --- compute changes as per starteam
 
-	    final Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(rootFolder, workspace);
+	    final Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(rootFolder, ignoreWorkingFolder, workspace);
 	    final Map<java.io.File, com.starbase.starteam.File> starteamFileMap = StarTeamFunctions.convertToFileMap(starteamFiles);
 	    final Collection<java.io.File> starteamFileSet = starteamFileMap.keySet();
 	    final Collection<StarTeamFilePoint> starteamFilePoint = StarTeamFilePointFunctions.convertFilePointCollection(starteamFiles);

--- a/src/main/java/hudson/plugins/starteam/StarTeamFunctions.java
+++ b/src/main/java/hudson/plugins/starteam/StarTeamFunctions.java
@@ -83,21 +83,21 @@ public class StarTeamFunctions {
 		return null;
 	}
 
-  public static Collection<File> listAllFiles(Map<String,Folder> rootFolderMap, java.io.File workspace) {
+  public static Collection<File> listAllFiles(Map<String,Folder> rootFolderMap, boolean ignoreWorkingFolder, java.io.File workspace) {
 		Collection<File> result = new ArrayList<File>();
 
     for (Map.Entry<String,Folder> f:rootFolderMap.entrySet()) {
-      result.addAll(listAllFiles(f.getValue(),workspace));
+      result.addAll(listAllFiles(f.getValue(), ignoreWorkingFolder, workspace));
     }
 
 		return result;
 	}
 
-  public static Collection<File> listAllFiles(Folder rootFolder, java.io.File workspace) {
+  public static Collection<File> listAllFiles(Folder rootFolder, boolean ignoreWorkingFolder, java.io.File workspace) {
 		Collection<File> result = new ArrayList<File>();
     // set root folder
 		String alternatePath = rootFolder.getAlternatePathFragment();
-		if (alternatePath == null)
+		if (alternatePath == null || ignoreWorkingFolder)
 		{
 			alternatePath = "";
 		}
@@ -105,14 +105,18 @@ public class StarTeamFunctions {
 		rootFolder.setAlternatePathFragment(actualPlace.getAbsolutePath());
 
 		// Get a list of all files
-		listAllFiles(result, rootFolder);
+		listAllFiles(result, rootFolder, ignoreWorkingFolder);
 
 		return result;
 	}
 
-  private static void listAllFiles(Collection<File> result, Folder folder) {
+  private static void listAllFiles(Collection<File> result, Folder folder, boolean ignoreWorkingFolder) {
     for (Folder f : folder.getSubFolders()) {
-      listAllFiles(result, f);
+        if(ignoreWorkingFolder) {
+            // Use relative hierarchy recursively
+            f.setAlternatePathFragment(folder.getFilePath(f.getName()));
+        }
+      listAllFiles(result, f, ignoreWorkingFolder);
     }
     // find items in this folder
     for (Item i : folder.getItems(folder.getView().getProject().getServer()

--- a/src/main/java/hudson/plugins/starteam/StarTeamPollingActor.java
+++ b/src/main/java/hudson/plugins/starteam/StarTeamPollingActor.java
@@ -45,6 +45,8 @@ public class StarTeamPollingActor implements FileCallable<Boolean> {
 	private final StarTeamViewSelector config;
 
 	private Collection<StarTeamFilePoint> historicFilePoints;
+        
+        private final boolean useWorkingFolder;
 
 	/**
 	 * Default constructor.
@@ -56,12 +58,13 @@ public class StarTeamPollingActor implements FileCallable<Boolean> {
 	 * @param viewname  starteam view name
 	 * @param foldername starteam parent folder name
 	 * @param config configuration selector
+         * @param ignoreWorkingFolder option to checkout file using a relative hierarchy
 	 * @param listener Hudson task listener.
 	 * @param historicFilePoints  
 	 */
 	public StarTeamPollingActor(String hostname, int port, String user,
 			String passwd, String projectname, String viewname,
-			String foldername, StarTeamViewSelector config, TaskListener listener, Collection<StarTeamFilePoint> historicFilePoints) {
+			String foldername, StarTeamViewSelector config, boolean useWorkingFolder, TaskListener listener, Collection<StarTeamFilePoint> historicFilePoints) {
 		this.hostname = hostname;
 		this.port = port;
 		this.user = user;
@@ -71,6 +74,7 @@ public class StarTeamPollingActor implements FileCallable<Boolean> {
 		this.foldername = foldername;
 		this.listener = listener;
 		this.config = config;
+                this.useWorkingFolder = useWorkingFolder;
 		this.historicFilePoints=historicFilePoints;
 	}
 
@@ -95,7 +99,7 @@ public class StarTeamPollingActor implements FileCallable<Boolean> {
 
 		StarTeamChangeSet changeSet = null;
 		try {
-			changeSet = connection.computeChangeSet(connection.getRootFolder(), f, historicFilePoints , listener.getLogger());
+			changeSet = connection.computeChangeSet(connection.getRootFolder(), useWorkingFolder, f, historicFilePoints , listener.getLogger());
 		} catch (StarTeamSCMException e) {
 			e.printStackTrace(listener.getLogger());
 		}

--- a/src/main/java/hudson/plugins/starteam/StarTeamSCM.java
+++ b/src/main/java/hudson/plugins/starteam/StarTeamSCM.java
@@ -51,6 +51,7 @@ public class StarTeamSCM extends SCM {
 	private final int port;
 	private final String labelname;
 	private final boolean promotionstate;
+        private final boolean ignoreWorkingFolder;
 
 	private final StarTeamViewSelector config;
 	
@@ -76,11 +77,12 @@ public class StarTeamSCM extends SCM {
 	 *            label name used for polling view contents
 	 * @param promotionstate 
 	 *            indication if label name is actual label name or a promotion state name
-	 *
+	 * @param ignoreWorkingFolder
+         *             option to ignore working folders and checkout all files in the workspace 
 	 */
 	@DataBoundConstructor
 	public StarTeamSCM(String hostname, int port, String projectname,
-			String viewname, String foldername, String username, String password, String labelname, boolean promotionstate) {
+			String viewname, String foldername, String username, String password, String labelname, boolean promotionstate, boolean ignoreWorkingFolder) {
 		this.hostname = hostname;
 		this.port = port;
 		this.projectname = projectname;
@@ -90,6 +92,7 @@ public class StarTeamSCM extends SCM {
 		this.passwd = password;
 		this.labelname = labelname;
 		this.promotionstate = promotionstate;
+                this.ignoreWorkingFolder = ignoreWorkingFolder;
 		StarTeamViewSelector result = null;
 		if ((this.labelname != null) && (this.labelname.length() != 0))
 		{
@@ -126,7 +129,7 @@ public class StarTeamSCM extends SCM {
 
 	    // Create an actor to do the checkout, possibly on a remote machine
 	    StarTeamCheckoutActor co_actor = new StarTeamCheckoutActor(hostname,
-	            port, user, passwd, projectname, viewname, foldername, config,
+	            port, user, passwd, projectname, viewname, foldername, config, ignoreWorkingFolder,
 	            changeLogFilePath, listener, build, filePointFilePath);
 	    if (workspace.act(co_actor)) {
 	        // change log is written during checkout (only one pass for
@@ -185,7 +188,7 @@ public class StarTeamSCM extends SCM {
 		// Create an actor to do the polling, possibly on a remote machine
 		StarTeamPollingActor p_actor = new StarTeamPollingActor(hostname, port,
 				user, passwd, projectname, viewname, foldername,
-				config, listener,
+				config, ignoreWorkingFolder, listener,
 				historicFilePoints);
 		if (workspace.act(p_actor)) {
 			status = true;
@@ -329,4 +332,13 @@ public class StarTeamSCM extends SCM {
 	public boolean isPromotionstate() {
 		return promotionstate;
 	}
+        
+        /**
+	 * Is the label a promotion state name?
+	 *
+	 * @return True if working folders are ignored during checkouts.
+	 */
+        public boolean isIgnoreWorkingFolder() {
+            return ignoreWorkingFolder;
+        }
 }

--- a/src/main/resources/hudson/plugins/starteam/StarTeamSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/starteam/StarTeamSCM/config.jelly
@@ -24,6 +24,9 @@
     <f:entry title="Label is Promotion State?" help="/plugin/starteam/help/stpromotionstate.html">
         <f:checkbox name="starteam.promotionstate" checked="${scm.promotionstate}"/>
     </f:entry>
+    <f:entry title="Ignore working folders?" help="/plugin/starteam/help/stignoreworkingfolder.html">
+        <f:checkbox name="starteam.ignoreWorkingFolder" checked="${scm.ignoreWorkingFolder}"/>
+    </f:entry>
 	<f:entry title="Folder name" help="/plugin/starteam/help/stfoldername.html">
 		<f:textbox name="starteam.foldername" value="${scm.foldername}" />
 	</f:entry>

--- a/src/main/webapp/help/stignoreworkingfolder.html
+++ b/src/main/webapp/help/stignoreworkingfolder.html
@@ -1,0 +1,6 @@
+<div>
+	<p>
+		When checked, the working folders will be ignored to ensure that the checkout
+                is done entirely within the build's workspace.
+	</p>
+</div>

--- a/src/test/java/hudson/plugins/starteam/StarTeamSCMTest.java
+++ b/src/test/java/hudson/plugins/starteam/StarTeamSCMTest.java
@@ -48,7 +48,7 @@ public class StarTeamSCMTest extends HudsonTestCase {
 	@Before
 	public void setUp() throws Exception {
 		super.setUp();
-		t = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, null, false) ;
+		t = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, null, false, true) ;
 	}
 		
 	/**
@@ -58,7 +58,8 @@ public class StarTeamSCMTest extends HudsonTestCase {
 	public void testConstructorStarTeamSCM()
 	{
 		    boolean promotionState = false;
-			StarTeamSCM t = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password,  labelName, promotionState) ;
+                    boolean ignoreWorkingFolder = true;
+			StarTeamSCM t = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password,  labelName, promotionState, ignoreWorkingFolder) ;
 			assertEquals(hostName,t.getHostname());
 			assertEquals(port,t.getPort());
 			assertEquals(projectName,t.getProjectname());
@@ -68,6 +69,7 @@ public class StarTeamSCMTest extends HudsonTestCase {
 			assertEquals(password,t.getPassword());
 			assertEquals(labelName,t.getLabelname());
 			assertEquals(promotionState,t.isPromotionstate());
+                        assertEquals(ignoreWorkingFolder,t.isIgnoreWorkingFolder());
 	}
 
 	   /**
@@ -80,7 +82,8 @@ public class StarTeamSCMTest extends HudsonTestCase {
         FreeStyleProject p = createFreeStyleProject();
         p.setAssignedLabel(s.getSelfLabel());
         boolean promotionState = false;
-        p.setScm(new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password,  labelName, promotionState));
+        boolean ignoreWorkingFolder = false;
+        p.setScm(new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password,  labelName, promotionState, ignoreWorkingFolder));
 
         FreeStyleBuild b = assertBuildStatusSuccess(p.scheduleBuild2(0, new Cause.UserCause()).get());
         assertTrue(b.getWorkspace().child(testFile).exists());  // use a file that is in the root directory of your project
@@ -93,9 +96,10 @@ public class StarTeamSCMTest extends HudsonTestCase {
 	@Bug(6881)
 	@Test
     public void testConfigRoundtrip() throws Exception {
-	    boolean promotionState = false;
+	boolean promotionState = false;
+        boolean ignoreWorkingFolder = false;
         FreeStyleProject project = createFreeStyleProject();
-        StarTeamSCM scm = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, labelName, promotionState) ;
+        StarTeamSCM scm = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, labelName, promotionState, ignoreWorkingFolder) ;
         project.setScm(scm);
 
         // config roundtrip
@@ -106,7 +110,7 @@ public class StarTeamSCMTest extends HudsonTestCase {
                 "hostname,port,projectname,viewname,foldername,username,password,labelname,promotionstate");
         
         promotionState = true;
-        scm = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, promotionName, promotionState) ;
+        scm = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, promotionName, promotionState, true) ;
         project.setScm(scm);
 
         // config roundtrip
@@ -125,8 +129,9 @@ public class StarTeamSCMTest extends HudsonTestCase {
     public void testCheckout() throws Exception {
         // prepare with base label
         boolean promotionState = false;
+        boolean ignoreWorkingFolder = false;
         FreeStyleProject project = createFreeStyleProject();
-        StarTeamSCM scm = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, labelName, promotionState) ;
+        StarTeamSCM scm = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, labelName, promotionState, ignoreWorkingFolder) ;
         project.setScm(scm);
         // config roundtrip
         submit(new WebClient().getPage(project,"configure").getFormByName("config"));
@@ -153,7 +158,7 @@ public class StarTeamSCMTest extends HudsonTestCase {
         Assert.assertTrue("There should be no changes", changes.isEmptySet());
         
         // move to previous label
-        scm = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, labelName+"Before", promotionState) ;
+        scm = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, labelName+"Before", promotionState, true) ;
         project.setScm(scm);
         submit(new WebClient().getPage(project,"configure").getFormByName("config"));
 
@@ -166,7 +171,7 @@ public class StarTeamSCMTest extends HudsonTestCase {
         Assert.assertFalse(commiters.isEmpty());
         
         // move to next label
-        scm = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, labelName+"After", promotionState) ;
+        scm = new StarTeamSCM(hostName, port, projectName, viewName, folderName, userName, password, labelName+"After", promotionState, true) ;
         project.setScm(scm);
         submit(new WebClient().getPage(project,"configure").getFormByName("config"));
 

--- a/src/test/java/hudson/plugins/starteam/StarteamCheckoutActorTest.java
+++ b/src/test/java/hudson/plugins/starteam/StarteamCheckoutActorTest.java
@@ -80,6 +80,7 @@ public class StarteamCheckoutActorTest {
 		String folderName = System.getProperty("test.starteam.foldername", "NGBL/source/ant");
 		String userName = System.getProperty("test.starteam.username", "");
 		String password = System.getProperty("test.starteam.password", "");
+                boolean ignoreWorkingFolder = false;
 		
 		FilePath changeLogFilePath = new FilePath( changeLogFile ) ;
 		FilePath filePointsFilePath = new FilePath(filePointsFile);
@@ -91,7 +92,7 @@ public class StarteamCheckoutActorTest {
 		}
 		
 		AbstractBuild<?,?> build = null;
-		StarTeamCheckoutActor starTeamCheckoutActor =  new StarTeamCheckoutActor( hostName, port, userName, password, projectName, viewName, folderName, config, changeLogFilePath, listener, build, filePointsFilePath) ;
+		StarTeamCheckoutActor starTeamCheckoutActor =  new StarTeamCheckoutActor( hostName, port, userName, password, projectName, viewName, folderName, config, ignoreWorkingFolder, changeLogFilePath, listener, build, filePointsFilePath) ;
 
 		return starTeamCheckoutActor ;
 	}

--- a/src/test/java/hudson/plugins/starteam/integration/StarTeamViewSelectorIntegrationTest.java
+++ b/src/test/java/hudson/plugins/starteam/integration/StarTeamViewSelectorIntegrationTest.java
@@ -82,7 +82,7 @@ public class StarTeamViewSelectorIntegrationTest {
 		starTeamConnection = new StarTeamConnection( hostName, port, userName, password, projectName, viewName, folderName, selector) ;
 		starTeamConnection.initialize(-1) ;
 		Folder rootFolder = starTeamConnection.getRootFolder();
-		Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(rootFolder, parentDirectory);
+		Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(rootFolder, true, parentDirectory);
 		Assert.assertNotNull(starteamFiles) ;
 		Assert.assertTrue( starteamFiles.size() > 0 ) ;
 		starTeamConnection.close() ;
@@ -108,7 +108,7 @@ public class StarTeamViewSelectorIntegrationTest {
 		starTeamConnection = new StarTeamConnection( hostName, port, userName, password, projectName, viewName, folderName, selector) ;
 		starTeamConnection.initialize(-1) ;
 		Folder rootFolder = starTeamConnection.getRootFolder();
-		Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(rootFolder, parentDirectory);
+		Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(rootFolder, true, parentDirectory);
 		Assert.assertNotNull(starteamFiles) ;
 		Assert.assertTrue( starteamFiles.size() > 0 ) ;
 		starTeamConnection.close() ;
@@ -123,7 +123,7 @@ public class StarTeamViewSelectorIntegrationTest {
 		starTeamConnection = new StarTeamConnection( hostName, port, userName, password, projectName, viewName, folderName, selector) ;
 		starTeamConnection.initialize(-1) ;
 		Folder rootFolder = starTeamConnection.getRootFolder();
-		Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(rootFolder, parentDirectory);
+		Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(rootFolder, true, parentDirectory);
 		Assert.assertNotNull(starteamFiles) ;
 		Assert.assertTrue( starteamFiles.size() > 0 ) ;
 		starTeamConnection.close() ;
@@ -147,7 +147,7 @@ public class StarTeamViewSelectorIntegrationTest {
 		starTeamConnection = new StarTeamConnection( hostName, port, userName, password, projectName, viewName, folderName, selector) ;
 		starTeamConnection.initialize(-1) ;
 		Folder rootFolder = starTeamConnection.getRootFolder();
-		Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(rootFolder, parentDirectory);
+		Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(rootFolder, true, parentDirectory);
 		Assert.assertNotNull(starteamFiles) ;
 		Assert.assertTrue( starteamFiles.size() > 0 ) ;
 		starTeamConnection.close() ;

--- a/src/test/java/hudson/plugins/starteam/integration/StarteamConnectionIntegrationTest.java
+++ b/src/test/java/hudson/plugins/starteam/integration/StarteamConnectionIntegrationTest.java
@@ -77,8 +77,8 @@ public class StarteamConnectionIntegrationTest {
 	 */
 	@Test
 	public void testFindAllFiles() {
-		
-		Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(starTeamConnection.getRootFolder(), parentDirectory);
+		boolean ignoreWorkingFolder = false;
+		Collection<com.starbase.starteam.File> starteamFiles = StarTeamFunctions.listAllFiles(starTeamConnection.getRootFolder(), ignoreWorkingFolder, parentDirectory);
 		Assert.assertNotNull(starteamFiles) ;
 		Assert.assertTrue( starteamFiles.size() > 0 ) ;
 		int i=0;
@@ -89,7 +89,7 @@ public class StarteamConnectionIntegrationTest {
 		}
 		starTeamConnection.close() ;
 	}
-	
+
 	/**
 	 * find all changed files in starteam repository.
 	 * @throws IOException 
@@ -111,7 +111,7 @@ public class StarteamConnectionIntegrationTest {
 		// there is no list of previous files 
 		Folder rootFolder = oldStarTeamConnection.getRootFolder();
 		File workspace = parentDirectory;
-		StarTeamChangeSet oldChangeSet = oldStarTeamConnection.computeChangeSet(rootFolder, workspace, null, System.out);
+		StarTeamChangeSet oldChangeSet = oldStarTeamConnection.computeChangeSet(rootFolder, true, workspace, null, System.out);
 
 		// a sanity check - everything in the old set should be new, because it doesn't have a previous build
 		Assert.assertNotNull(oldChangeSet) ;
@@ -129,7 +129,7 @@ public class StarteamConnectionIntegrationTest {
 		
 		// get the change set from connection using historical list of files
 		rootFolder = starTeamConnection.getRootFolder();
-		StarTeamChangeSet newChangeSet = starTeamConnection.computeChangeSet(rootFolder, workspace, historicStarteamFilePoint, System.out);
+		StarTeamChangeSet newChangeSet = starTeamConnection.computeChangeSet(rootFolder, true, workspace, historicStarteamFilePoint, System.out);
 		Assert.assertNotNull(newChangeSet) ;
 		Assert.assertTrue(newChangeSet.isComparisonAvailable()) ;
 		Assert.assertTrue(newChangeSet.hasChanges()) ;


### PR DESCRIPTION
This is a nice-to-have and I'll understand if you don't deem it necessary. :) But we often run into the situation where users will have overwritten the default working folder on their servers, which leads to artifacts being downloaded outside of the slave's workspace. I added a checkbox to ignore the working folders and check everything out relatively from the workspace's root.

Thanks.